### PR TITLE
Add: security header to be sent to external endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Security headers to be sent to external endpoint.
+
 ## [0.0.3] - 2024-06-21
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -34,6 +34,17 @@
         "title": "Webhook URL",
         "description": "The URL that will receive the webhook",
         "type": "string"
+      },
+      "token": {
+        "title": "Token",
+        "description": "The token to authenticate the webhook sent as X-PS2WEBHOOK-API-AppToken",
+        "type": "string"
+      },
+      "key": {
+        "title": "Key",
+        "format": "password",
+        "description": "The key to authenticate the webhook sent as X-PS2WEBHOOK-API-AppKey",
+        "type": "string"
       }
     }
   },

--- a/node/clients/webhook.ts
+++ b/node/clients/webhook.ts
@@ -7,6 +7,8 @@ export default class Webhook extends ExternalClient {
       ...options,
       headers: {
         ...options?.headers,
+        'X-PS2WEBHOOK-API-AppToken': context.settings.token,
+        'X-PS2WEBHOOK-API-AppKey': context.settings.key,
         'X-Vtex-Use-Https': 'true',
       },
     })


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add support to key and token for security measures.

#### What problem is this solving?

Increase the security layer

#### How to test it?

Add a token and key at the configurations:
https://dunnesstoresqa.myvtex.com/admin/apps/vtex.psv2-webhook@0.0.4-beta.0/setup/

<img width="1109" alt="image" src="https://github.com/vtex-apps/psv2-webhook/assets/67066494/e8b95db2-8168-457d-bb1a-d78196cd006d">

This will be sent as a header when calling the external endpoint.

<img width="1251" alt="image" src="https://github.com/vtex-apps/psv2-webhook/assets/67066494/0e61fa05-2f0a-47df-a31f-a170f1764a8e">


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->


![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExOHgxbnV5cjFyaXR2YmF2bTNtNzZhMzg3OG9pa2l4Z2NoeGJvOWFtaCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/QX1l5T6Kcl2DtoWGy4/giphy.gif)

#### Types of changes

- [ ] Chore (non-breaking change which doesn't change any functionalities)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
