### PR TITLE
Adjust header app key and token to be optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Adjust client to send event without app key or token configured. 
+
 ## [0.0.5] - 2024-07-09
 
 ### Added

--- a/node/clients/webhook.ts
+++ b/node/clients/webhook.ts
@@ -3,14 +3,19 @@ import { ExternalClient } from '@vtex/api'
 
 export default class Webhook extends ExternalClient {
   constructor(context: IOContext, options?: InstanceOptions) {
+    const headers: Record<string, string> = {
+      ...options?.headers,
+      'X-Vtex-Use-Https': 'true',
+    }
+
+    if (context.settings.token && context.settings.key) {
+      headers['X-PS2WEBHOOK-API-AppToken'] = context.settings.token
+      headers['X-PS2WEBHOOK-API-AppKey'] = context.settings.key
+    }
+
     super(context.settings.webhookUrl, context, {
       ...options,
-      headers: {
-        ...options?.headers,
-        'X-PS2WEBHOOK-API-AppToken': context.settings.token,
-        'X-PS2WEBHOOK-API-AppKey': context.settings.key,
-        'X-Vtex-Use-Https': 'true',
-      },
+      headers,
     })
   }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

The event should be fired even if the application do not have an app key and token configured to increase the security level for the external integrator.

#### What problem is this solving?

Fixing a bug introduced at:
https://github.com/vtex-apps/psv2-webhook/pull/3

#### How to test it?

You can test at qa and check that the event is now fired even without the header:

<img width="1256" alt="image" src="https://github.com/user-attachments/assets/7754ab43-d184-450d-868a-9f9f844a7f61">

App:
https://dunnesstoresqa.myvtex.com/admin/apps/vtex.psv2-webhook@0.x/setup/

<img width="1199" alt="image" src="https://github.com/user-attachments/assets/b5e849f3-4d81-4a67-b0dd-2e4f3262ffe2">


#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExaTFtbmo0Y2dnemR4ZzU1ZHp4b253YjBwbHc1cGU5NjJycjluZG1pbyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/5ZZSYqvcH6QppFQGI5/giphy-downsized.gif)

#### Types of changes

- [ ] Chore (non-breaking change which doesn't change any functionalities)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
